### PR TITLE
Refactor `RateEstimate`

### DIFF
--- a/interstellar.gemspec
+++ b/interstellar.gemspec
@@ -8,7 +8,7 @@ require 'interstellar/version'
 Gem::Specification.new do |spec|
   spec.name = 'interstellar'
   spec.version = Interstellar::VERSION
-  spec.date = '2022-01-12'
+  spec.date = '2022-01-22'
 
   spec.authors = [
     'Third Party Transportation Systems LLC',

--- a/lib/interstellar/version.rb
+++ b/lib/interstellar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Interstellar
-  VERSION = '0.1.pre3'
+  VERSION = '0.1.pre4'
 end


### PR DESCRIPTION
1. Convert `RateEstimate` to `Model` and reconfigure attributes, remove the ever-expanding `options` `Hash`
2. Bump version to 0.1.pre4