### PR TITLE
Add `Shipment#hazmat?`

### DIFF
--- a/lib/interstellar/models/shipment.rb
+++ b/lib/interstellar/models/shipment.rb
@@ -20,6 +20,10 @@ module Interstellar
       packages.map(&:packaging).map(&:pallet?).none?(true)
     end
 
+    def hazmat?
+      packages.map(&:hazmat?).any?(true)
+    end
+
     def loose_and_palletized?
       !loose? && !palletized?
     end


### PR DESCRIPTION
Simplify determining whether a `Shipment` is considered hazmat based on its `#packages`